### PR TITLE
func(fdiv): add fdivc's OpType to package.scala

### DIFF
--- a/src/main/scala/yunsuan/package.scala
+++ b/src/main/scala/yunsuan/package.scala
@@ -52,6 +52,7 @@ package object yunsuan {
     def fge           = "b10001000".U(OpTypeWidth.W) // fge(src1,src2)
     def fsub          = "b10001001".U(OpTypeWidth.W) // src1 - src2
     def fmacc         = "b00001010".U(OpTypeWidth.W) // vd = +(src1 * src2) + vd
+    def fdiv          = "b00001011".U(OpTypeWidth.W) // vd = src2 / src1
     
     def isVfalu(vfpuType: UInt) = vfpuType(7) & !vfpuType(6)
   }

--- a/src/main/scala/yunsuan/vector/VectorFloatDivider.scala
+++ b/src/main/scala/yunsuan/vector/VectorFloatDivider.scala
@@ -19,7 +19,7 @@ class VectorFloatDivider() extends Module {
     val finish_valid_o = Output(Bool())
     val finish_ready_i = Input(Bool())
     val fpdiv_res_o = Output(UInt(64.W))
-    val fflags_o = Output(UInt(5.W))
+    val fflags_o = Output(UInt(20.W))
 
   })
 


### PR DESCRIPTION
* func(fdiv): add fdivc's OpType to package.scala
* fix(vfdiv):fix bug that the bit widths of fflags_0 in VectorFloatDivider should be 20