### PR TITLE
VPU: fix vcompress , vfredsum/max/min , vpermtest

### DIFF
--- a/src/main/scala/yunsuan/vector/VectorFloatAdder.scala
+++ b/src/main/scala/yunsuan/vector/VectorFloatAdder.scala
@@ -574,6 +574,7 @@ class FloatAdderF32WidenF16MixedPipeline(val is_print:Boolean = false,val hasMin
       Cat(0.U(16.W), fp_bFix(15, 0))
     )
     val out_NAN = Mux(res_is_f32, Cat(0.U,Fill(8,1.U),1.U,0.U(22.W)), Cat(0.U(17.W),Fill(5,1.U),1.U,0.U(9.W)))
+    val out_Nzero = Mux(res_is_f32, Cat(1.U, 0.U(31.W)), Cat(0.U(16.W), 1.U, 0.U(15.W)))
     val fp_a_16_or_32 = Mux(res_is_f32, fp_aFix(31, 0), Cat(0.U(16.W), fp_aFix(15, 0)))
     val fp_b_16_or_32 = Mux(res_is_f32, fp_bFix(31, 0), Cat(0.U(16.W), fp_bFix(15, 0)))
     result_min := Mux1H(
@@ -628,7 +629,7 @@ class FloatAdderF32WidenF16MixedPipeline(val is_print:Boolean = false,val hasMin
     val is_fsum_ore_masked = is_fsum_ore && !io.maskForReduction(0)
     val result_fsum_ure_masked = Mux(
       io.maskForReduction === 0.U,
-      0.U(floatWidth.W),
+      out_Nzero,
       Mux(io.maskForReduction(0), io.fp_a, io.fp_b)
     )
     val result_fsum_ore_masked = Mux(
@@ -1856,6 +1857,7 @@ class FloatAdderF64WidenPipeline(val is_print:Boolean = false,val hasMinMaxCompa
     val result_fmerge = Mux(io.mask, fp_bFix, fp_aFix)
     val result_fmove = fp_bFix
     val out_NAN = Cat(0.U, Fill(exponentWidth, 1.U), 1.U, Fill(significandWidth - 2, 0.U))
+    val out_Nzero = Cat(1.U, Fill(floatWidth - 1, 0.U))
     result_min := Mux1H(
       Seq(
         !fp_a_is_NAN & !fp_b_is_NAN,
@@ -1908,7 +1910,7 @@ class FloatAdderF64WidenPipeline(val is_print:Boolean = false,val hasMinMaxCompa
     val is_fsum_ore_masked = is_fsum_ore && !io.maskForReduction(0)
     val result_fsum_ure_masked = Mux(
       io.maskForReduction === 0.U,
-      0.U(floatWidth.W),
+      out_Nzero,
       Mux(io.maskForReduction(0), io.fp_a, io.fp_b)
     )
     val result_fsum_ore_masked = Mux(
@@ -2525,6 +2527,7 @@ class FloatAdderF16Pipeline(val is_print:Boolean = false,val hasMinMaxCompare:Bo
     val result_fmerge = Mux(io.mask, fp_bFix, fp_aFix)
     val result_fmove  = fp_bFix
     val out_NAN = Cat(0.U,Fill(exponentWidth,1.U),1.U,Fill(significandWidth-2,0.U))
+    val out_Nzero = Cat(1.U, Fill(floatWidth - 1, 0.U))
     result_min := Mux1H(
       Seq(
         !fp_a_is_NAN & !fp_b_is_NAN,
@@ -2577,7 +2580,7 @@ class FloatAdderF16Pipeline(val is_print:Boolean = false,val hasMinMaxCompare:Bo
     val is_fsum_ore_masked = is_fsum_ore && !io.maskForReduction(0)
     val result_fsum_ure_masked = Mux(
       io.maskForReduction === 0.U,
-      0.U(floatWidth.W),
+      out_Nzero,
       Mux(io.maskForReduction(0), io.fp_a, io.fp_b)
     )
     val result_fsum_ore_masked = Mux(

--- a/src/test/scala/vector/VectorALU/VPermSpec.scala
+++ b/src/test/scala/vector/VectorALU/VPermSpec.scala
@@ -36,7 +36,7 @@ trait VPermBehavior {
         // vcomprss lmul=2
         genVPermInput(SrcBundle("hc4d5e6dbc4d5e6d8b2a19063b2a19060", "h7c048cfb7c048cf869d0368369d03680",  "h579be00b579be0084567899345678990", "h0"), vcompress.copy(u8, u8, mask, vm = true, ta = false, ma=false, vlmul=1, vl=32)),
         genVPermInput(SrcBundle("hc4d5e6dbc4d5e6d8b2a19063b2a19060", "h7c048cfb7c048cf869d0368369d03680",  "h579be00b579be0084567899345678990", "h0"), vcompress.copy(u8, u8, mask, vm = true, ta = false, ma=false, vlmul=1, vl=32, uopIdx = 1)),
-        genVPermInput(SrcBundle("he93e93cbe93e93c8d70a3d53d70a3d50", "h7c048cfb7c048cf869d0368369d03680",  "h579be00b579be008456789e6dbd5e6b2", "h5"), vcompress.copy(u8, u8, mask, vm = true, ta = false, ma=false, vlmul=1, vl=32, uopIdx = 2)),
+        genVPermInput(SrcBundle("he93e93cbe93e93c8d70a3d53d70a3d50", "h5007c048cfb7c048cf869d0368369d0",  "h579be00b579be008456789e6dbd5e6b2", "h5"), vcompress.copy(u8, u8, mask, vm = true, ta = false, ma=false, vlmul=1, vl=32, uopIdx = 2)),
         genVPermInput(SrcBundle("he93e93cbe93e93c8d70a3d53d70a3d50", "h7c048cfb7c048cf869d0368369d03680",  "h7c048cfb7c048cf869d0368369d03680", "h5"), vcompress.copy(u8, u8, mask, vm = true, ta = false, ma=false, vlmul=1, vl=32, uopIdx = 3)),
         // vslide1up lmul=1
         genVPermInput(SrcBundle("h6d3a06d06d3a06d75b05b0585b05b05f", "h07070707070707070707070707070707",  "h48d159e048d159e7369d0368369d036f", "h2468acf02468acf7123456781234567f"), vslide1up.copy(u8, u8, u8, vm = false, ta = false, ma = false, vl=16)),
@@ -89,7 +89,7 @@ trait VPermBehavior {
         genVAluOutput("h8344c0aa5b76129530ac75dc32000f06"),
         // vcompress, lmul=2
         genVAluOutput("h579be00b579be008456789e6dbd5e6b2"),
-        genVAluOutput("h5"),
+        genVAluOutput("h5007c048cfb7c048cf869d0368369d0"),
         genVAluOutput("h579be00b3e93e9c8d70a53e6dbd5e6b2"),
         genVAluOutput("h7c048cfb7c048cf869d0368369d03680"),
         // vslide1up, lmul=1


### PR DESCRIPTION
fix vfredsum/max/min: 
    When the vector vfredusum/max/min consists entirely of inactive elements and vs1[0] is NaN, the result should be vs1[0]
    When both elements of vfredusum are inactive, the temporary result changes from positive zero to negative zero.
fix vcompress to fit v0/vl split:
    The vcompress calculation combines the ones_sum result with vs1 using a temporary register to reduce one read operation. Additionally, other uops, except ones_sum, reduce the basemask calculation and the right shift basemask operation.
fix vpermtest to fit new vcompress