### PR TITLE
fix(InToFp): fix the bit-width non-parameterization problem of fp_exp in the postnorm

### DIFF
--- a/src/main/scala/yunsuan/scalar/IntToFP.scala
+++ b/src/main/scala/yunsuan/scalar/IntToFP.scala
@@ -72,6 +72,7 @@ class IntToFP_postnorm(val expWidth: Int, val precision: Int) extends Module {
     (io.in.norm_int, io.in.lzc, io.in.is_zero, io.in.sign, io.rm)
 
   val exp_raw = (63 + FloatPoint.expBias(expWidth)).U(11.W) - lzc
+
   val sig_raw = in.head(precision - 1) // exclude hidden bit
   val round_bit = in.tail(precision - 1).head(1)
   val sticky_bit = in.tail(precision).orR
@@ -92,6 +93,8 @@ class IntToFP_postnorm(val expWidth: Int, val precision: Int) extends Module {
   val fp_sig = rounder.io.out
   val flow = fp_exp>((1<<expWidth)-2).U  // underflow or overflow
 
+  val final_fp_exp = fp_exp(expWidth-1,0)
+
   nv := false.B
   dz := false.B
   of := !in_sign && flow
@@ -99,7 +102,7 @@ class IntToFP_postnorm(val expWidth: Int, val precision: Int) extends Module {
   nx := flow || ix
 
   io.result := Mux(flow, Mux(rmin, Cat(in_sign, FloatPoint.maxNormExp(expWidth).U(expWidth.W), ~0.U((precision-1).W)),
-                  Cat(in_sign, ~0.U(expWidth.W), 0.U((precision-1).W))), Cat(in_sign, fp_exp, fp_sig))
+                  Cat(in_sign, ~0.U(expWidth.W), 0.U((precision-1).W))), Cat(in_sign, final_fp_exp, fp_sig))
   io.fflags := Cat(nv, dz, of, uf, nx)
 }
 


### PR DESCRIPTION
在IntToFP_postnorm中，fp_exp的位宽会被chisel设置成11。这个对于单精度与半精度来说过长的fp_exp会导致结果超过预设位宽，符号位偏离原来的位置，进而被截断。