### PR TITLE
feat(mgu): support vlenb mask generate unit and chiseltest

### DIFF
--- a/src/main/scala/yunsuan/vector/v2/MergeUnit.scala
+++ b/src/main/scala/yunsuan/vector/v2/MergeUnit.scala
@@ -1,0 +1,79 @@
+package yunsuan.vector.v2
+
+import chisel3._
+import chisel3.util._
+
+object MergeUnit {
+  def apply(vlen: Int): MergeUnit = {
+    val mgu = new MergeUnit(vlen)
+    mgu
+  }
+  class In(vlen: Int) extends Bundle {
+    val ctrl = new InCtrl
+    val data = new InData(vlen)
+  }
+  class Out(vlen: Int) extends Bundle {
+    val vlenb = vlen / 8
+    val activeEn   = UInt(vlenb.W)
+    val agnosticEn = UInt(vlenb.W)
+    val res        = Vec(vlenb, UInt(8.W))
+  }
+  class InCtrl extends Bundle {
+    val vma = Bool()
+    val vta = Bool()
+  }
+  class InData(vlen: Int) extends  Bundle {
+    val vlenb = vlen / 8
+    val mask  = UInt(vlenb.W)
+    val begin = UInt(log2Ceil(vlenb + 1).W)
+    val end   = UInt(log2Ceil(vlenb + 1).W)
+    val oldVd = Vec(vlenb, UInt(8.W))
+    val vd    = Vec(vlenb, UInt(8.W))
+  }
+}
+
+class MergeUnit(vlen: Int = 128) extends Module {
+  val vlenb = vlen / 8
+  val in  = IO(Input(new MergeUnit.In(vlen)))
+  val out = IO(Output(new MergeUnit.Out(vlen)))
+
+  private val vma    = in.ctrl.vma
+  private val vta    = in.ctrl.vta
+  private val maskEn = in.data.mask
+  private val begin  = in.data.begin
+  private val end    = in.data.end
+  private val vd     = in.data.vd
+  private val oldVd  = in.data.oldVd
+
+  assert(begin <= vlenb.U, "begin should less than or equal to vlenb")
+  assert(end   <= vlenb.U, "begin should less than or equal to vlenb")
+
+  private val beginMask = Wire(UInt(vlenb.W))
+  private val endMask   = Wire(UInt(vlenb.W))
+  private val tailMask  = Wire(UInt(vlenb.W))
+  beginMask := (Fill(vlenb, 1.U) << begin)((vlenb << 1) - 1, vlenb)
+  endMask   := (Fill(vlenb, 1.U) << end)((vlenb << 1) - 1, vlenb)
+  tailMask  := ~endMask
+
+  private val bodyMask = ~beginMask & endMask
+
+  private val maskOffEn = ~maskEn
+
+  private val activeMask = bodyMask & maskEn
+  private val agnosticMask = Fill(vlenb, vma) & bodyMask & maskOffEn | Fill(vlenb, vta) & tailMask
+
+  private val bytes1s = (~0.U(8.W)).asUInt
+
+  // oldVd and byte1s have good timing
+  private val resTmp = Wire(Vec(vlenb, UInt(8.W)))
+  for (i <- 0 until vlenb) {
+    resTmp(i) := Mux(agnosticMask(i), bytes1s, oldVd(i))
+  }
+
+  out.activeEn := activeMask
+  out.agnosticEn := agnosticMask
+
+  for (i <- 0 until vlenb) {
+    out.res(i) := Mux(activeMask(i), vd(i), resTmp(i))
+  }
+}

--- a/src/test/scala/vector/VectorTest.scala
+++ b/src/test/scala/vector/VectorTest.scala
@@ -8,14 +8,25 @@ import chiseltest._
 import chiseltest.ChiselScalatestTester
 import chiseltest.VerilatorBackendAnnotation
 import chiseltest.simulator.{VerilatorFlags, VerilatorCFlags}
-// import freechips.rocketchip.util.{ElaborationArtefacts, HasRocketChipStageUtils}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
+import yunsuan.vector.v2.MergeUnit
+
+import scala.math.BigInt
+import scala.util.Random
+
 object GenTest extends App {
-  val path = """./generated/VectorIdiv"""
+  val path = """./generated/MergeUnit"""
   (new ChiselStage).execute(
-    Array("--target-dir", path),
-    Seq(ChiselGeneratorAnnotation(() => new VectorIdiv), FirtoolOption("--disable-all-randomization"))
+    Array(
+      "--target", "systemverilog",
+      "--target-dir", path
+    ),
+    Seq(
+      ChiselGeneratorAnnotation(() => MergeUnit(128)),
+      FirtoolOption("--disable-all-randomization"),
+      FirtoolOption("--strip-debug-info")
+    )
   )
 }
 
@@ -192,6 +203,99 @@ class VIntDividerTest extends AnyFlatSpec with ChiselScalatestTester with Matche
       // TargetDirAnnotation("./build"),
     )) { dut =>
       dut.clock.step(10)
+    }
+  }
+}
+
+class MergeUnitTest extends AnyFlatSpec with ChiselScalatestTester with Matchers with HasTestAnnos {
+
+  def refModel(
+    vlenb: Int,
+    mask: BigInt,
+    begin: Int,
+    end: Int,
+    vma: Boolean,
+    vta: Boolean
+  ): (BigInt, BigInt) = {
+    val allOnes = (BigInt(1) << vlenb) - BigInt(1)
+    val width = end - begin
+
+    val body = (((BigInt(1) << width) - BigInt(1)) << begin) & allOnes
+    val tail = (~((BigInt(1) << end) - BigInt(1))) & allOnes
+
+    val activeEn = body & mask
+    val agnosticEn =
+      (if (vma) body & ~mask else BigInt(0)) |
+      (if (vta) tail else BigInt(0))
+    
+    (activeEn, agnosticEn)
+  }
+
+  behavior of "MergeUnit"
+  it should "compute activeEn, agnosticEn, res correctly" in {
+    test(MergeUnit(128)).withAnnotations(Seq(VerilatorBackendAnnotation)) { dut =>
+
+      val vlenb = 128 / 8
+      val rand = new Random()
+      val num = 2000
+
+      // reset
+      dut.reset.poke(true.B)
+      dut.clock.step(2)
+      dut.reset.poke(false.B)
+
+      for (i <- 0 until num) {
+        // random inputs
+        val begin = rand.nextInt(vlenb)
+        val end   = rand.nextInt(vlenb)
+        val (b, e) = if (begin <= end) (begin, end) else (end, begin)
+
+        val mask = BigInt(vlenb, rand)
+        val vma = rand.nextBoolean()
+        val vta = rand.nextBoolean()
+
+        val vd = Seq.fill(vlenb)(rand.nextInt(256))
+        val oldVd = Seq.fill(vlenb)(rand.nextInt(256))
+
+        // poke
+        dut.in.ctrl.vma.poke(vma.B)
+        dut.in.ctrl.vta.poke(vta.B)
+
+        dut.in.data.mask.poke(mask.U)
+        dut.in.data.begin.poke(b.U)
+        dut.in.data.end.poke(e.U)
+
+        vd.zipWithIndex.foreach { case (v, i) =>
+          dut.in.data.vd(i).poke(v.U)
+        }
+        oldVd.zipWithIndex.foreach { case (v, i) =>
+          dut.in.data.oldVd(i).poke(v.U)
+        }
+
+        dut.clock.step(1)
+
+        // reference
+        val (expectedActiveEn, expectedAgnosticEn) = refModel(vlenb, mask, b, e, vma, vta)
+
+        dut.out.activeEn.expect(expectedActiveEn.U)
+        dut.out.agnosticEn.expect(expectedAgnosticEn.U)
+
+        val bytes1s = ((BigInt(1) << 8) - BigInt(1)).toInt
+
+        val expectedRes = (0 until vlenb).map { i => 
+          val a = (expectedActiveEn >> i) & BigInt(1)
+          val b = (expectedAgnosticEn >> i) & BigInt(1)
+          if (a == BigInt(1)) vd(i)
+          else if (b == BigInt(1)) bytes1s
+          else oldVd(i)
+        }
+
+        dut.out.res.zip(expectedRes).foreach { case (r, v) =>
+          r.expect(v.U)
+        }
+      }
+
+      dut.clock.step(5)
     }
   }
 }


### PR DESCRIPTION
* This PR supports receiving `byte-level` `masks` and `begin/end` indicators for the `Vlenb` bit, generating corresponding `activeEn/agnosticEn` information, then performing a selection operation on the input two-byte Vec (`oldVd` and `Vd`) to output the byte Vec.